### PR TITLE
Add RL trading environment with baseline PPO agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# rl_crypto_trading_bot
+# RL Crypto Trading Bot
+
+This repository contains a simple reinforcement learning setup for training a
+cryptocurrency trading agent.
+
+## Components
+
+- `rl/env.py` – OpenAI Gym–compatible environment based on portfolio value
+  changes.
+- `rl/baseline.py` – Utilities for training and running a PPO agent with
+  Stable‑Baselines3.
+- `rl/train.py` – Command line entry point for training.
+- `rl/infer.py` – Command line entry point for inference.
+
+## Usage
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Train the agent on historical data stored in `prices.csv`:
+
+```bash
+python -m rl.train prices.csv --timesteps 10000 --out ppo_trading
+```
+
+Run inference using the trained model:
+
+```bash
+python -m rl.infer prices.csv --model ppo_trading
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+gym
+stable-baselines3
+pandas
+numpy

--- a/rl/__init__.py
+++ b/rl/__init__.py
@@ -1,0 +1,1 @@
+"""Reinforcement learning utilities for crypto trading."""

--- a/rl/baseline.py
+++ b/rl/baseline.py
@@ -1,0 +1,68 @@
+"""Baseline agent utilities using Stable-Baselines3.
+
+This module provides helper functions to train a simple PPO agent on the
+:class:`TradingEnv` environment and to run inference with a saved model.
+"""
+from __future__ import annotations
+
+import pandas as pd
+from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import DummyVecEnv
+
+from .env import TradingEnv
+
+
+def load_data(csv_path: str) -> pd.DataFrame:
+    """Load market data from a CSV file.
+
+    The CSV file must contain at least a ``price`` column.
+    """
+    return pd.read_csv(csv_path)
+
+
+def train(data_path: str, timesteps: int = 10_000,
+          model_path: str = "ppo_trading") -> None:
+    """Train a PPO agent on the :class:`TradingEnv`.
+
+    Parameters
+    ----------
+    data_path: str
+        Path to a CSV file containing the historical price data.
+    timesteps: int
+        Number of timesteps to train for.
+    model_path: str
+        Location where the trained model will be saved.
+    """
+    data = load_data(data_path)
+    env = DummyVecEnv([lambda: TradingEnv(data)])
+    model = PPO("MlpPolicy", env, verbose=0)
+    model.learn(total_timesteps=timesteps)
+    model.save(model_path)
+
+
+def run_inference(data_path: str, model_path: str = "ppo_trading") -> float:
+    """Run inference using a trained model.
+
+    Parameters
+    ----------
+    data_path: str
+        Path to CSV file with market data.
+    model_path: str
+        Path to the saved model.
+
+    Returns
+    -------
+    float
+        Final portfolio value after running the agent on the dataset.
+    """
+    data = load_data(data_path)
+    env = TradingEnv(data)
+    model = PPO.load(model_path)
+
+    obs = env.reset()
+    done = False
+    while not done:
+        action, _ = model.predict(obs)
+        obs, _, done, info = env.step(int(action))
+
+    return float(info["portfolio_value"])

--- a/rl/env.py
+++ b/rl/env.py
@@ -1,0 +1,86 @@
+import gym
+from gym import spaces
+import numpy as np
+import pandas as pd
+
+class TradingEnv(gym.Env):
+    """A simple trading environment for reinforcement learning.
+
+    The environment consumes a price series provided via a ``pandas``
+    ``DataFrame`` with a ``price`` column. The observation consists of the
+    current price, cash balance and asset holdings. Actions are:
+
+    * 0 - hold
+    * 1 - buy with all available cash
+    * 2 - sell all holdings
+
+    Rewards are the change in portfolio value across timesteps.
+    """
+
+    metadata = {"render.modes": ["human"]}
+
+    def __init__(self, data: pd.DataFrame, initial_balance: float = 1000.0,
+                 fee: float = 0.001):
+        super().__init__()
+        if "price" not in data.columns:
+            raise ValueError("data must contain a 'price' column")
+        self.data = data.reset_index(drop=True)
+        self.initial_balance = initial_balance
+        self.fee = fee
+
+        # Action space: hold, buy, sell
+        self.action_space = spaces.Discrete(3)
+        # Observation: price, balance, holdings
+        self.observation_space = spaces.Box(low=0.0, high=np.inf, shape=(3,),
+                                            dtype=np.float32)
+
+        self.reset()
+
+    def _get_obs(self) -> np.ndarray:
+        price = float(self.data.loc[self.current_step, "price"])
+        return np.array([price, self.balance, self.holdings],
+                        dtype=np.float32)
+
+    def _portfolio_value(self, price: float) -> float:
+        return self.balance + self.holdings * price
+
+    def step(self, action: int):
+        price = float(self.data.loc[self.current_step, "price"])
+        prev_value = self._portfolio_value(price)
+
+        if action == 1:  # buy
+            qty = self.balance / price
+            cost = qty * price * (1 + self.fee)
+            if cost <= self.balance:
+                self.balance -= cost
+                self.holdings += qty
+        elif action == 2:  # sell
+            revenue = self.holdings * price * (1 - self.fee)
+            self.balance += revenue
+            self.holdings = 0.0
+
+        self.current_step += 1
+        done = self.current_step >= len(self.data) - 1
+
+        next_price = float(self.data.loc[self.current_step, "price"])
+        current_value = self._portfolio_value(next_price)
+        reward = current_value - prev_value
+
+        obs = self._get_obs()
+        info = {"portfolio_value": current_value}
+        return obs, reward, done, info
+
+    def reset(self):  # type: ignore[override]
+        self.balance = float(self.initial_balance)
+        self.holdings = 0.0
+        self.current_step = 0
+        return self._get_obs()
+
+    def render(self, mode: str = "human") -> None:
+        price = float(self.data.loc[self.current_step, "price"])
+        value = self._portfolio_value(price)
+        print(
+            f"Step: {self.current_step} | Price: {price:.2f} | "
+            f"Balance: {self.balance:.2f} | Holdings: {self.holdings:.4f} | "
+            f"Value: {value:.2f}"
+        )

--- a/rl/infer.py
+++ b/rl/infer.py
@@ -1,0 +1,18 @@
+"""Command line entry point for running inference with a trained model."""
+import argparse
+
+from . import baseline
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run inference with PPO model")
+    parser.add_argument("data", help="Path to CSV file with price data")
+    parser.add_argument("--model", default="ppo_trading",
+                        help="Path to the trained model")
+    args = parser.parse_args()
+    value = baseline.run_inference(args.data, model_path=args.model)
+    print(f"Final portfolio value: {value:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rl/train.py
+++ b/rl/train.py
@@ -1,0 +1,19 @@
+"""Command line entry point for training the baseline agent."""
+import argparse
+
+from . import baseline
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train PPO trading agent")
+    parser.add_argument("data", help="Path to CSV file with price data")
+    parser.add_argument("--timesteps", type=int, default=10_000,
+                        help="Number of training timesteps")
+    parser.add_argument("--out", default="ppo_trading",
+                        help="Where to save the trained model")
+    args = parser.parse_args()
+    baseline.train(args.data, timesteps=args.timesteps, model_path=args.out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `TradingEnv` gym environment with portfolio-based rewards
- add Stable-Baselines3 PPO training and inference utilities
- document usage and include dependencies

## Testing
- `python -m pytest`
- `python -m rl.train --help` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement gym)*

------
https://chatgpt.com/codex/tasks/task_e_6899f70910088321a01374612403beda