### PR TITLE
Add CLI for training and trading modes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,56 @@
+import argparse
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Command line interface for the RL crypto trading bot"
+    )
+    parser.add_argument(
+        "--symbol",
+        type=str,
+        help="Trading pair symbol, e.g., BTCUSDT",
+    )
+    parser.add_argument(
+        "--papertrading",
+        action="store_true",
+        help="Run in paper trading mode instead of live trading",
+    )
+    action_group = parser.add_mutually_exclusive_group(required=True)
+    action_group.add_argument(
+        "--train",
+        action="store_true",
+        help="Train the reinforcement learning agent",
+    )
+    action_group.add_argument(
+        "--run",
+        action="store_true",
+        help="Run the trading bot",
+    )
+    args = parser.parse_args()
+    return parser, args
+
+
+def main():
+    parser, args = parse_args()
+
+    if args.train:
+        if not args.symbol:
+            parser.error("--symbol is required when training")
+        from train import train_agent
+
+        train_agent(args.symbol)
+    elif args.run:
+        if not args.symbol:
+            parser.error("--symbol is required when running")
+        if args.papertrading:
+            from paper_trader import run_paper_trading
+
+            run_paper_trading(args.symbol)
+        else:
+            from live_trader import run_live_trading
+
+            run_live_trading(args.symbol)
+
+
+if __name__ == "__main__":
+    main()

--- a/live_trader.py
+++ b/live_trader.py
@@ -1,0 +1,9 @@
+"""Live trading module for the RL crypto trading bot."""
+
+def run_live_trading(symbol: str) -> None:
+    """Placeholder live trading routine.
+
+    Args:
+        symbol: Trading pair symbol.
+    """
+    print(f"Running live trading for {symbol}...")

--- a/paper_trader.py
+++ b/paper_trader.py
@@ -1,0 +1,9 @@
+"""Paper trading module for the RL crypto trading bot."""
+
+def run_paper_trading(symbol: str) -> None:
+    """Placeholder paper trading routine.
+
+    Args:
+        symbol: Trading pair symbol.
+    """
+    print(f"Running paper trading for {symbol}...")

--- a/train.py
+++ b/train.py
@@ -1,0 +1,9 @@
+"""Training module for the RL crypto trading bot."""
+
+def train_agent(symbol: str) -> None:
+    """Placeholder training routine.
+
+    Args:
+        symbol: Trading pair symbol.
+    """
+    print(f"Training agent for {symbol}...")


### PR DESCRIPTION
## Summary
- Add `cli.py` using argparse with options for `--symbol`, `--papertrading`, `--train`, and `--run`
- Dispatch to training, paper trading, or live trading modules
- Add placeholder modules for training, paper trading, and live trading

## Testing
- `python -m py_compile cli.py train.py paper_trader.py live_trader.py`
- `python cli.py --help`
- `python cli.py --train --symbol BTCUSDT`
- `python cli.py --run --papertrading --symbol BTCUSDT`
- `python cli.py --run --symbol BTCUSDT`


------
https://chatgpt.com/codex/tasks/task_e_6899f70e1f2c8321993b920cf02a0251